### PR TITLE
Release 0.10.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    smart_udap_harmonization_test_kit (0.9.0)
+    smart_udap_harmonization_test_kit (0.10.0)
       inferno_core (~> 0.6.2)
       smart_app_launch_test_kit (~> 0.4.3)
       udap_security_test_kit (~> 0.10.3)

--- a/lib/smart_udap_harmonization_test_kit/version.rb
+++ b/lib/smart_udap_harmonization_test_kit/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module SMART_UDAP_HarmonizationTestKit
-  VERSION = '0.9.0'
-  LAST_UPDATED = '2024-11-12'
+  VERSION = '0.10.0'
+  LAST_UPDATED = '2026-02-27'
 end


### PR DESCRIPTION
## Breaking Changes:
- **Ruby Version Update:** Upgraded Ruby to `3.3.6`.
- **Inferno Core Update:** Bumped to version `0.6`.
- **Gemspec Updates:**
  - Switched to `git` for specifying files.
  - Added `presets` to the gem package.
  - Updated any test kit dependencies
- **Test Kit Metadata:** Implemented Test Kit metadata for Inferno Platform.
- **Environment Updates:** Updated Ruby version in the Dockerfile and GitHub Actions workflow.
