### PR TITLE
Fix Docker session creation

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,3 @@
 REDIS_URL=redis://redis:6379/0
+INFERNO_HOST=http://localhost
 FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500


### PR DESCRIPTION
# Summary

Previously, when this test kit was [run locally in docker](https://inferno-framework.github.io/docs/getting-started-users.html#running-an-existing-test-kit), users creating sessions within the Inferno UI would be redirected to a page on port 4567 which was not found. Now, users are correctly redirected to the main Inferno UI for the session.

# Testing Guidance

1. Start the test kit [using docker](https://inferno-framework.github.io/docs/getting-started-users.html#running-an-existing-test-kit).
2. Open http://localhost in a web browser.
3. Click the "Start Testing" button.
4. Confirm that a web page for the testing session opens correctly.